### PR TITLE
fix(ci): use flutter-channel in publish workflow and fix tag format

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish Package
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - '*.*.*'
   workflow_dispatch:
     inputs:
       dry-run:
@@ -17,7 +17,7 @@ jobs:
     name: Publish to pub.dev
     uses: banua-coder/banua-coder-workflow/.github/workflows/publish-dart.yml@v1
     with:
-      flutter-version: 'stable'
+      flutter-channel: 'stable'
       use-flutter: true
       dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
       environment: 'pub.dev'

--- a/.pubignore
+++ b/.pubignore
@@ -24,3 +24,5 @@ coverage/
 
 doc/api/
 pubspec.yaml.bak
+build/
+WORKFLOWS.md


### PR DESCRIPTION
## Summary
- Fix publish workflow Flutter setup error by using `flutter-channel` instead of `flutter-version: 'stable'`
- Fix tag pattern from `v*.*.*` to `*.*.*` (we don't use `v` prefix in version tags)

## Changes
- Changed `flutter-version: 'stable'` to `flutter-channel: 'stable'` in publish.yml
- Updated tag trigger pattern to match our versioning convention